### PR TITLE
Fix priority queue IndexError

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "shortestpaths" %}
-{% set version = "1.1.2" %}
+{% set version = "1.1.3" %}
 
 package:
   name: "{{ name|lower }}"

--- a/shortestpaths/__init__.py
+++ b/shortestpaths/__init__.py
@@ -11,9 +11,9 @@
 # ==========================================================================
 """Special project variables & API"""
 
-from shortestpaths.api import k_shortest_paths, replacement_paths
-from shortestpaths.post import print_paths, plot_paths
-from shortestpaths.graph import random_graph, adj_list_reversed
+from shortestpaths.api import k_shortest_paths, replacement_paths  # noqa: F401
+from shortestpaths.post import print_paths, plot_paths  # noqa: F401
+from shortestpaths.graph import random_graph, adj_list_reversed  # noqa: F401
 
 
 __name__ = 'shortestpaths'

--- a/shortestpaths/__init__.py
+++ b/shortestpaths/__init__.py
@@ -17,7 +17,7 @@ from shortestpaths.graph import random_graph, adj_list_reversed  # noqa: F401
 
 
 __name__ = 'shortestpaths'
-__version__ = '1.1.2'
+__version__ = '1.1.3'
 __author__ = 'Athanasios Mattas'
 __author_email__ = 'thanasismatt@gmail.gr'
 __description__ = "Bidirectional replacement paths and k-shortest paths search with dynamic programming"

--- a/shortestpaths/dijkstra.py
+++ b/shortestpaths/dijkstra.py
@@ -819,9 +819,12 @@ def bidirectional_dijkstra(forward_config,
 
   Args:
     forward_config (dict) : forward search kwargs
-    reverse_config (dict) : reverse serach kwargs
+    reverse_config (dict) : reverse search kwargs
     mode (dict)           : the configuration of the simulation
     failed (hashable)     : the failed node, if any (default: None)
+    prospect (list)       : the candidate path [path_cost, u, v, edge_cost] -
+                            (u, v) is the meeting edge (default: None)
+    top_reverse (int)     : the root of the reverse pqueue (default: None)
 
   Returns:
     path, path_cost, cum_hop_weights, meeting_edge_head

--- a/shortestpaths/dijkstra.py
+++ b/shortestpaths/dijkstra.py
@@ -765,7 +765,10 @@ def _dijkstra_step(adj_list,
   Used for the alternately steps of the two searches at bidirectional Dijkstra.
   """
   u_path_cost, u_prev, u = to_visit.pop_low()
-  priorityq_top = to_visit.peek()[0]
+  if not to_visit:
+    priorityq_top = 0
+  else:
+    priorityq_top = to_visit.peek()[0]
   if priorityq_top == math.inf:
     priorityq_top = 0
 

--- a/shortestpaths/yen.py
+++ b/shortestpaths/yen.py
@@ -30,7 +30,7 @@ def fail_found_spur_edges(adj_list,
                           k_paths,
                           adj_list_reverse=None,
                           head=None):
-  """Failes the edges having spur-node as tail, for each of the K - k found
+  """Fails the edges having spur-node as tail, for each of the K - k found
   paths, that have the same root-path with the prospect-path."""
   # {head: (head, edge_cost)}
   failed_edges = dict()


### PR DESCRIPTION
Fixes #3.
The [PriorityQueue](https://github.com/ThanasisMattas/shortestpaths/blob/26fe2f468ab0a3c1d87ced6332ae44690cd9ed37/shortestpaths/priorityq.py#L20C1-L20C1) can be empty inside a [_dijkstra_step()](https://github.com/ThanasisMattas/shortestpaths/blob/26fe2f468ab0a3c1d87ced6332ae44690cd9ed37/shortestpaths/dijkstra.py#L755) and, thus, it cannot be picked.